### PR TITLE
Remove unused import.

### DIFF
--- a/polymer-build-mobile/step2/index.html
+++ b/polymer-build-mobile/step2/index.html
@@ -10,7 +10,6 @@
   <link rel="stylesheet" href="styles.css">
 
   <script src="bower_components/platform/platform.js"></script>
-  <link rel="import" href="bower_components/core-header-panel/core-header-panel.html">
   <link rel="import" href="codelab-app.html">
 </head>
 


### PR DESCRIPTION
This line was left over from the initial sample app - it should be removed completely in step 2 since all the imports are in codelab-app.html.
