### PR TITLE
Should not share data array among all polymer instances.

### DIFF
--- a/polymer-build-mobile/step5/codelab-app.html
+++ b/polymer-build-mobile/step5/codelab-app.html
@@ -47,7 +47,9 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
+    create: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step6/codelab-app.html
+++ b/polymer-build-mobile/step6/codelab-app.html
@@ -49,7 +49,9 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
+    create: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step7/codelab-app.html
+++ b/polymer-build-mobile/step7/codelab-app.html
@@ -72,8 +72,10 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
     fontSize: 14,
+    create: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step8/codelab-app.html
+++ b/polymer-build-mobile/step8/codelab-app.html
@@ -77,8 +77,10 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
     fontSize: 14,
+    create: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },


### PR DESCRIPTION
The data array will be shared by all instances since it is defined in the prototype.  This is not what is desired.  Though moot in this case (the app is intended to be a singleton), we should not be encouraging developers to make this mistake in their element prototypes.

I suggest using the lifecycle callback "create" to initialize a new data array for each instance.
