### PR TITLE
Don't share data array between instances.

### DIFF
--- a/polymer-build-mobile/end/codelab-app.html
+++ b/polymer-build-mobile/end/codelab-app.html
@@ -77,8 +77,10 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
     fontSize: 14,
+    created: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step5/codelab-app.html
+++ b/polymer-build-mobile/step5/codelab-app.html
@@ -47,7 +47,9 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
+    created: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step6/codelab-app.html
+++ b/polymer-build-mobile/step6/codelab-app.html
@@ -49,7 +49,9 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
+    created: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step7/codelab-app.html
+++ b/polymer-build-mobile/step7/codelab-app.html
@@ -72,8 +72,10 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
     fontSize: 14,
+    created: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },

--- a/polymer-build-mobile/step8/codelab-app.html
+++ b/polymer-build-mobile/step8/codelab-app.html
@@ -77,8 +77,10 @@
 </template>
 <script>
   Polymer('codelab-app', {
-    data: [],
     fontSize: 14,
+    created: function () {
+      this.data = [];
+    },
     toggleDrawer: function() {
       this.$.drawerPanel.togglePanel();
     },


### PR DESCRIPTION
The previous code shared the data array among all the instances of the polymer element.  Moot in the case of a singleton, but not the intended behavior.
